### PR TITLE
Remove Contributor Compensation page.

### DIFF
--- a/docs/contributing/contributor-compensation.md
+++ b/docs/contributing/contributor-compensation.md
@@ -1,3 +1,0 @@
-# <img class="dcr-icon" src="/img/dcr-icons/ObtainingDecred.svg" /> Contributor Compensation
-
----

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,5 +82,4 @@ nav:
   - 'Core Values': 'contributing/core-values.md'
   - 'Contributor Guidelines': 'contributing/contributor-guidelines.md'
   - 'Community': 'contributing/community.md'
-  - 'Contributor Compensation': 'contributing/contributor-compensation.md'
 copyright: If you wish to improve this site, please <a href="https://github.com/decred/dcrdevdocs/issues/new"><i class="fa fa-github"></i> open an issue</a> or <a href="https://github.com/decred/dcrdevdocs/compare"><i class="fa fa-github"></i> send a pull request</a>.<br>dcrdevdocs v0.0.1. Decred Project 2019.


### PR DESCRIPTION
It occurs to me that this site is specifically for **dev** contributors and not likely to be visited by non-devs. The "Contributor Compensation" page should probably stay on the main docs.decred.org site because that is relevant for **all** contributors.