### PR TITLE
Adds compensation section

### DIFF
--- a/docs/contributing/contributor-guidelines.md
+++ b/docs/contributing/contributor-guidelines.md
@@ -16,6 +16,10 @@ Once you've found something you'd like to work on, announce your plans **before*
 
 Some repos will also have their own specific guidelines. For instance, the dcrd repo has fairly extensive [Code Contribution Guidelines](https://github.com/decred/dcrd/blob/master/docs/code_contribution_guidelines.md).
 
+## Getting Paid
+
+Decred has a Treasury fund to pay contributors who work effectively to advance the project. For details about how this works, see the [Contributing](https://docs.decred.org/contributing/overview/) section of the regular Decred docs.  
+
 ## GitHub
 
 While different repos may have slightly different GitHub processes, below are the basic steps common to all repos.


### PR DESCRIPTION
Have added a 'Getting Paid' section to the 'Contributor Guidelines' page ( Closes #31 ). 

Kept the description short and sweet. Just adding a brief description and linking to dcrdocs. I think putting it here, as its own section in the Contributor Guidelines page makes sense, as it is a unique value proposition of Decred, and that process is open to anyone making meaningful contributions. Also, can't think of a non awkward place to put it currently. 

