### PR TITLE
Add signature info raedah notes

### DIFF
--- a/docs/core-blockchain-concepts/transactions/transaction-format.md
+++ b/docs/core-blockchain-concepts/transactions/transaction-format.md
@@ -24,21 +24,10 @@ Outputs      | Serialized list of all the transaction's outputs                 
 Lock time    | The time when a transaction can be spent. (usually zero, in which case it has no effect)       | 4 bytes
 Expiry       | The block height at which the transaction expires and is no longer valid                       | 4 bytes
 
-### Bitcoin similarities
-
-Decred originally began as fork of the Bitcoin client [btcd](https://github.com/btcsuite/btcd),
-and its transaction format has similarities to Bitcoin's.
-However, to address some issues Bitcoin transactions had at the time,
-Decred implemented separate fields that allowed for script versioning and transaction immalleability.
-Bitcoin later added support for these features in the SegWit [soft fork](https://en.wikipedia.org/wiki/SegWit). However, to avoid a hard fork and preserve backwards compatibility,
-Bitcoin implemented these changes inside the signature scripts, not as separate fields.
-In this respect, Decred and Bitcoin transactions are conceptually similar,
-but differ somewhat in their implementation.
 
 ### Inputs
 
-In Decred, there are two types of transaction inputs: witness and non-witness.
-A non-witness transaction input is a reference to an unspent output
+An input is a reference to an unspent output from a previous transaction. In Decred, there are two types of transaction inputs: witness and non-witness. A non-witness transaction input is a reference to an unspent output
 (inputs spend previously-made outputs), and a sequence number.
 A witness transaction input contains the data necessary to prove that an output can be spent.
 

--- a/docs/core-blockchain-concepts/transactions/transactions.md
+++ b/docs/core-blockchain-concepts/transactions/transactions.md
@@ -13,3 +13,32 @@ In addition to regular transactions (sending DCR from one address to another), t
 * **Coinbase transaction:** Every block which is mined contains a single coinbase transaction. A coinbase transaction will typically have three outputs: one output that contains the encoded block height (used to ensure that coinbase hash collisions are impossible), one output that creates the coins added to the project treasury (10% of the block reward), and one output that creates the coins paid to the PoW miner for creating the block (60% of the block reward). Coinbase transactions are part of the regular transaction tree, which means that they will be rejected if Proof-of-Stake (PoS) voters vote to disapprove the block which contains them. Decred created in coinbase transactions cannot be spent until the coinbase maturity period has passed.
 * **Stakebase transaction:** Every block starting at the stake validation height which is mined will contain a stakebase transaction for each ticket which voted on that block. The stakebase transaction will identify the ticket that voted, as well as produce the Decred which was spent to purchase the ticket, and the newly created Decred constituting the voting reward. Stakebase transactions belong to the stake transaction tree, which means that these transactions cannot be rejected by PoS voters, even if they vote to disapprove the block which contains them.
 * **Multisignature:** Multisignature refers to transactions which can be authorized by more than one private key. Multisignature transactions can support multiple keys (N) and a subset of those (M) are required to transact (commonly known as “MofN”). For example, a 2 of 3 multisignature transaction would have three valid keys, however only two of them would be required to authorize. Multisignature transactions are in the regular transaction tree.
+
+## Bitcoin Differences
+
+Decred transactions are created in a similar way to Bitcoin, with a couple notable differences.
+
+### Transaction Format
+
+Decred originally began as fork of the Bitcoin client [btcd](https://github.com/btcsuite/btcd),
+and its [transaction format](transaction-format.md) has similarities to Bitcoin's.
+However, to address some issues Bitcoin transactions had at the time,
+Decred implemented separate fields that allowed for script versioning and transaction immalleability.
+Bitcoin later added support for these features in the SegWit [soft fork](https://en.wikipedia.org/wiki/SegWit). However, to avoid a hard fork and preserve backwards compatibility,
+Bitcoin implemented these changes inside the signature scripts, not as separate fields.
+In this respect, Decred and Bitcoin transactions are conceptually similar,
+but differ somewhat in their implementation.
+
+### Hashing Algorithm
+
+While Bitcoin uses the [SHA-256](https://en.bitcoinwiki.org/wiki/SHA-256) hashing algorithm to calculate the transaction hash (hash of the Tx containing the output being spent), Decred uses the [blake256r14](https://docs.decred.org/research/blake-256-hash-function/) hashing algorithm. 
+
+Likewise, when hashing a public key to generate an address (e.g. a Pay-to-PubkeyHash (P2PKH) address), Decred uses blake256r14 instead of SHA-256. The full algorithm to create an address is blake256r14+ripemd160+base58.
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Adding info about signatures from raedah's notes ( #30 ).
https://github.com/raedahgroup/dcrdevdocs/blob/master/start.md#signatures

While I was here, made a couple other suggested changes:

- Added definition of input on the Transactions Format page
- Moved the Bitcoin Differences section to Transactions page, where I think it fits better (differences from Bitcoin is a high level concept that seems good to introduce early)
