### PR TITLE
Update color scheme

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -3,10 +3,7 @@
 .md-footer-nav,
 .md-footer-meta,
 .md-nav__source {
-    background-color: #3f51b5;
-    
-/*    color: #091440;
-    font-weight: bold;*/
+    background-color: #2970FF;
 }
 
 /* Highlight current page in nav menu */
@@ -47,7 +44,7 @@ p img.dcr-icon {
     	background-color: #091440;
     }
     .md-nav__source {
-    	background-color: #122c5c;
+    	background-color: #2970FF;
     }
 }
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -3,7 +3,10 @@
 .md-footer-nav,
 .md-footer-meta,
 .md-nav__source {
-    background-color: #091440
+    background-color: #3f51b5;
+    
+/*    color: #091440;
+    font-weight: bold;*/
 }
 
 /* Highlight current page in nav menu */

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -41,7 +41,7 @@ p img.dcr-icon {
 
 @media only screen and (max-width: 76.1875em){
     html .md-nav--primary .md-nav__title--site {
-    	background-color: #091440;
+    	background-color: #2970FF;
     }
     .md-nav__source {
     	background-color: #2970FF;


### PR DESCRIPTION
To differentiate from dcrdocs, have changed the background color of the header to a different shade of blue ( Closes #40 ). 

**Dcrdocs current**
![image](https://user-images.githubusercontent.com/1634777/66790234-cdb85380-eea3-11e9-8f1d-6dbe06269c8f.png)

**Dcrdevdocs proposed**
![image](https://user-images.githubusercontent.com/1634777/66790214-b711fc80-eea3-11e9-8fbe-415e80daa8b8.png)

I think this could also be a nice opportunity to further differentiate dcrdocs by updating its logo from monochrome to color gradient (below), which I think makes the docs slicker and more professional anyway.

![image](https://user-images.githubusercontent.com/1634777/66790323-22f46500-eea4-11e9-87b9-e1a0c390cedc.png)
